### PR TITLE
About 12% faster TCL

### DIFF
--- a/Interpreted/ackermann-function/ack.tcl
+++ b/Interpreted/ackermann-function/ack.tcl
@@ -1,12 +1,16 @@
 interp recursionlimit {} [expr {10000}]
 
+namespace import ::tcl::mathop::*
+
 proc ack {m n} {
-    if {$m == 0} {
-        expr {$n + 1}
-    } elseif {$n == 0} {
-        ack [expr {$m - 1}] 1
+    if {! $m} {
+        incr n
+    } elseif {! $n} {
+	incr m -1
+        ack $m 1
     } else {
-        ack [expr {$m - 1}] [ack $m [expr {$n - 1}]]
+        incr n -1
+        ack [- $m 1] [ack $m $n]
     }
 }
 


### PR DESCRIPTION
My off hand measurements show about a 12% improvement by slightly changing the TCL code.
Increment and decrement are fastest with the incr command.
Use ::tcl::mathop::- over nested expr.  
The expression $m == 0 is faster as ! $m.